### PR TITLE
Fix use case when removing last variant from current version #35

### DIFF
--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -115,6 +115,7 @@ export default class ProductManager {
   removeVariantsFromProduct (product, skus) {
     const masterData = product.masterData
     const actions = []
+    let unpublishProduct = false
 
     masterData.current.variants = masterData.current.variants || []
     masterData.staged.variants = masterData.staged.variants || []
@@ -124,82 +125,85 @@ export default class ProductManager {
       staged: this._getVariantsBySkuMap(masterData.staged)
     }
 
+    const deletedSkus = {
+      current: [],
+      staged: []
+    }
+
     // delete from map all variants specified in skus param
     Object.keys(productVersions).forEach(version =>
       skus.forEach((sku) => {
-        delete productVersions[version][sku]
+        if (productVersions[version][sku]) {
+          delete productVersions[version][sku]
+          deletedSkus[version].push(sku)
+        }
       })
     )
 
-    let currentSkus = Object.keys(productVersions.current)
-    let stagedSkus = Object.keys(productVersions.staged)
+    const retainedSkus = {
+      staged: Object.keys(productVersions.staged),
+      current: Object.keys(productVersions.current)
+    }
 
     // if there are no variants left delete whole product
-    if (currentSkus.length === 0 && stagedSkus.length === 0)
+    if (retainedSkus.current.length === 0 && retainedSkus.staged.length === 0)
       return this.deleteByProduct(product)
 
-    // if there are no current variants left
-    //  - unpublish product
-    //  - add all variants from staged to current
-    if (currentSkus.length === 0) {
-      currentSkus = _.cloneDeep(stagedSkus)
-      productVersions.current = _.cloneDeep(productVersions.staged)
+    // if there are no variants left in current:
+    //  - publish product so we get staged variants to current
+    //  - set unpublish flag so the product is unpublished at the end
+    if (retainedSkus.current.length === 0) {
+      actions.push(this._getPublishAction())
 
-      actions.push(this._getUnpublishAction())
-      stagedSkus.forEach(sku =>
-        actions.push(
-          this._getAddVariantAction(productVersions.staged[sku], false)
-        )
-      )
+      // we copied variants from staged to current so we should
+      // update also local maps
+      deletedSkus.current = _.cloneDeep(deletedSkus.staged)
+      retainedSkus.current = _.cloneDeep(retainedSkus.staged)
+      productVersions.current = _.cloneDeep(productVersions.staged)
+      masterData.current = _.cloneDeep(masterData.staged)
+      // unpublish at the end
+      unpublishProduct = true
     }
 
     // if there are no staged variants left
     //  - add all variants from current to staged
-    if (stagedSkus.length === 0) {
-      stagedSkus = _.cloneDeep(currentSkus)
+    if (retainedSkus.staged.length === 0) {
+      retainedSkus.staged = _.cloneDeep(retainedSkus.current)
       productVersions.staged = _.cloneDeep(productVersions.current)
 
-      stagedSkus.forEach(sku =>
+      retainedSkus.staged.forEach(sku =>
         actions.push(
           this._getAddVariantAction(productVersions.current[sku], true)
         )
       )
     }
 
-    // if we want to delete a masterVariant from current, set another variant as
-    // new masterVariant first
-    if (this._isMasterVariantRemoved(masterData.current, currentSkus)) {
-      const firstExistingVariant = Object.values(productVersions.current)[0]
-
-      actions.push(
-        this._getChangeMasterVariantAction(firstExistingVariant, false)
-      )
-    }
-
-    // if we want to delete a masterVariant from staged, set another variant as
-    // new masterVariant first
-    if (this._isMasterVariantRemoved(masterData.staged, stagedSkus)) {
-      const firstExistingVariant = Object.values(productVersions.staged)[0]
-
-      actions.push(
-        this._getChangeMasterVariantAction(firstExistingVariant, true)
-      )
-    }
-
     // run through both variants (staged and current)
-    // first remove variants from staged
+    // first change masterVariants if needed and then remove variants
     ['staged', 'current'].forEach((version) => {
       const variantMap = this._getVariantsBySkuMap(masterData[version])
 
+      // if we deleted a masterVariant, set another variant as new masterVariant
+      if (this._isMasterVariantRemoved(masterData[version], retainedSkus[version])) {
+        const firstExistingVariant = Object.values(productVersions[version])[0]
+
+        actions.push(
+          this._getChangeMasterVariantAction(firstExistingVariant, version === 'staged')
+        )
+      }
+
       // remove variants specified in skus param
       // but only if product has this variant
-      skus.forEach((sku) => {
+      deletedSkus[version].forEach((sku) => {
         if (variantMap[sku])
           actions.push(
             this._getRemoveVariantAction(variantMap[sku], version === 'staged')
           )
       })
     })
+
+    if (unpublishProduct)
+      actions.push(this._getUnpublishAction())
 
     return actions.length
       ? this.updateProduct(product, actions)
@@ -278,6 +282,12 @@ export default class ProductManager {
   _getUnpublishAction () {
     return {
       action: 'unpublish'
+    }
+  }
+
+  _getPublishAction () {
+    return {
+      action: 'publish'
     }
   }
 

--- a/spec/integration/runner/variant-reassignment-example-15.spec.js
+++ b/spec/integration/runner/variant-reassignment-example-15.spec.js
@@ -1,3 +1,4 @@
+import { expect } from 'chai'
 import * as utils from '../../utils/helper'
 import VariantReassignment from '../../../lib/runner/variant-reassignment'
 
@@ -37,7 +38,8 @@ describe.skip('Variant reassignment', () => {
         version: product1.version,
         actions: [{ action: 'publish' }]
       })
-    product1Response = await ctpClient.products
+
+    await ctpClient.products
       .byId(product1.id)
       .update({
         version: product1Response.body.version,

--- a/spec/unit/product-manager.spec.js
+++ b/spec/unit/product-manager.spec.js
@@ -53,9 +53,9 @@ describe('ProductManager', () => {
       const product = getMockProduct()
       const actions = productService.removeVariantsFromProduct(product, ['1'])
       expect(actions).to.deep.equal([
-        { action: 'changeMasterVariant', staged: false, sku: '2' },
         { action: 'changeMasterVariant', staged: true, sku: '2' },
         { action: 'removeVariant', staged: true, sku: '1' },
+        { action: 'changeMasterVariant', staged: false, sku: '2' },
         { action: 'removeVariant', staged: false, sku: '1' }
       ])
     })
@@ -75,13 +75,12 @@ describe('ProductManager', () => {
       const actions = productService.removeVariantsFromProduct(product, ['1'])
 
       expect(actions).to.deep.equal([
-        { action: 'unpublish' },
-        { action: 'addVariant', staged: false, sku: '2' },
-        { action: 'addVariant', staged: false, sku: '3' },
-        { action: 'changeMasterVariant', staged: false, sku: '2' },
+        { action: 'publish' },
         { action: 'changeMasterVariant', staged: true, sku: '2' },
         { action: 'removeVariant', staged: true, sku: '1' },
-        { action: 'removeVariant', staged: false, sku: '1' }
+        { action: 'changeMasterVariant', staged: false, sku: '2' },
+        { action: 'removeVariant', staged: false, sku: '1' },
+        { action: 'unpublish' }
       ])
     })
 
@@ -95,10 +94,10 @@ describe('ProductManager', () => {
 
       expect(actions).to.deep.equal([
         { action: 'addVariant', staged: true, sku: '2' },
-        { action: 'changeMasterVariant', staged: false, sku: '2' },
         { action: 'changeMasterVariant', staged: true, sku: '2' },
         { action: 'removeVariant', staged: true, sku: '1' },
         { action: 'removeVariant', staged: true, sku: '3' },
+        { action: 'changeMasterVariant', staged: false, sku: '2' },
         { action: 'removeVariant', staged: false, sku: '1' },
         { action: 'removeVariant', staged: false, sku: '3' }
       ])
@@ -121,10 +120,10 @@ describe('ProductManager', () => {
       )
 
       expect(actions).to.deep.equal([
-        { action: 'changeMasterVariant', staged: false, sku: '2' },
         { action: 'changeMasterVariant', staged: true, variantId: 2 },
         { action: 'removeVariant', staged: true, sku: '3' },
         { action: 'removeVariant', staged: true, id: 1 },
+        { action: 'changeMasterVariant', staged: false, sku: '2' },
         { action: 'removeVariant', staged: false, id: 3 },
         { action: 'removeVariant', staged: false, sku: '1' }
       ])

--- a/spec/utils/helper.js
+++ b/spec/utils/helper.js
@@ -197,7 +197,7 @@ export async function createCtpProducts (skuGroups, ctpClient, beforeProductCrea
   const masterVariantSkus = []
   for (let i = 0; i < skuGroups.length; i++) {
     const skus = skuGroups[i]
-    const productDraft = generateProduct(skus, productType.id)
+    const productDraft = generateProductProjection(skus, productType.id)
     if (beforeProductCreateCb)
       beforeProductCreateCb(productDraft)
     const product = await ensureResource(ctpClient.products, productDraft)


### PR DESCRIPTION
Fixes #35

When we want to remove last current variant we decided to unpublish product, push staged variants to current and then remove that one current variant.

The problem is that it is not possible to add variants to the current which are in staged by simple `addVariant` action with `staged: false`. The only way how we can move variants is to publish product so with this fix we are publishing product to propagate staged variants to current and then unpublishing it because we removed current variants so the product should not appear in the product catalog.