### PR TITLE
3 error handling

### DIFF
--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -497,10 +497,10 @@ export default class VariantReassignment {
     return false
   }
 
-  _removeVariantsFromCtpProductToUpdate (anonymizedProductDraft, ctpProductToUpdate) {
+  async _removeVariantsFromCtpProductToUpdate (anonymizedProductDraft, ctpProductToUpdate) {
     const skusToRemove = this.productService.getProductDraftSkus(anonymizedProductDraft)
     this.logger.debug('Removing %d variants from ctpProductToUpdate', skusToRemove.length)
-    return this.productService.removeVariantsFromProduct(ctpProductToUpdate, skusToRemove)
+    await this.productService.removeVariantsFromProduct(ctpProductToUpdate, skusToRemove)
   }
 
   async _createVariantsInCtpProductToUpdate (backupVariants, productDraft, ctpProductToUpdate) {

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -50,25 +50,24 @@ export default class VariantReassignment {
       productDraftsForReassignment.length
     )
 
-    if (productDraftsForReassignment.length)
-      for (const productDraft of productDraftsForReassignment)
-        try {
-          await this._processProductDraft(productDraft, products)
-        } catch (e) {
-          this.logger.error(
-            'Error while processing productDraft %j, retrying.',
-            productDraft.name, e.toString()
-          )
-          await this._handleProcessingError(productDraft, products)
-        }
+    for (const productDraft of productDraftsForReassignment)
+      try {
+        await this._processProductDraft(productDraft, products)
+      } catch (e) {
+        this.logger.error(
+          'Error while processing productDraft %j, retrying.',
+          productDraft.name, e.toString()
+        )
+        await this._handleProcessingError(productDraft, products)
+      }
 
     return Promise.resolve()
   }
 
   async _handleProcessingError (productDraft, products) {
     const transactions = await this.transactionService.getTransactions()
-    const failedTransaction = transactions.find(transaction =>
-      _.isEqual(transaction.newProductDraft.name, productDraft.name)
+    const failedTransaction = transactions.find(({ value }) =>
+      _.isEqual(value.newProductDraft.name, productDraft.name)
     )
 
     return failedTransaction
@@ -96,16 +95,22 @@ export default class VariantReassignment {
    * @private
    */
   async _processUnfinishedTransactions (transactions = null) {
-    this.logger.debug('Loading unfinished transactions')
-    transactions = transactions || await this.transactionService.getTransactions()
+    if (!transactions) {
+      this.logger.debug('Loading unfinished transactions')
+      transactions = await this.transactionService.getTransactions()
+    }
 
     for (const transactionObject of transactions) {
-      const key = transactionObject.key
-      const transaction = transactionObject.value
+      const { key, value: transaction } = transactionObject
 
       this.logger.debug('Processing unfinished transaction with key %s', key)
-      await this._createAndExecuteActions(transaction.newProductDraft,
-        transaction.backupProductDraft, transaction.variants, transaction.ctpProductToUpdate)
+      await this._createAndExecuteActions(
+        transaction.newProductDraft,
+        transaction.backupProductDraft,
+        transaction.variants,
+        transaction.ctpProductToUpdate,
+        transactionObject
+      )
     }
   }
 
@@ -152,12 +157,18 @@ export default class VariantReassignment {
     if (!matchingProducts) {
       matchingProducts = await this._selectMatchingProducts(productDraft)
       // load CTP product to update for backupProductDraft -> CTP product to update
+
       const productToUpdateCandidate
         = this._selectCtpProductToUpdate(productDraft, matchingProducts)
-      if (this.productService.isProductsSame(productToUpdateCandidate, ctpProductToUpdate))
+
+      // if there is no ctpProductToUpdate or it is the same as candidate, take candidate
+      if (!ctpProductToUpdate
+        ||
+        this.productService.isProductsSame(productToUpdateCandidate, ctpProductToUpdate)
+      )
         ctpProductToUpdate = productToUpdateCandidate
       else
-      // ctpProductToUpdate has been deleted and not recreated with correct product type id
+        // ctpProductToUpdate has been deleted and not recreated with correct product type id
         await this._createNewProduct(ctpProductToUpdate, productDraft.productType.id)
     }
 
@@ -168,6 +179,7 @@ export default class VariantReassignment {
       ctpProductToUpdate = await this._changeProductType(
         transaction, ctpProductToUpdate, draftProductType
       )
+
     matchingProducts
       = await this._removeVariantsFromMatchingProducts(backupVariants, matchingProducts)
     // when creating variant, also ensure about sameForAll attrs - Examples 9,10,11

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -56,10 +56,16 @@ export default class VariantReassignment {
       } catch (e) {
         this.logger.error(
           'Error while processing productDraft %j, retrying.',
-          productDraft.name, e.toString()
+          productDraft.name, e.stack
         )
         await this._handleProcessingError(productDraft, products)
+      } finally {
+        this.logger.debug(
+          'Finished processing of productDraft with name %j',
+          productDraft.name
+        )
       }
+
 
     return Promise.resolve()
   }
@@ -104,13 +110,19 @@ export default class VariantReassignment {
       const { key, value: transaction } = transactionObject
 
       this.logger.debug('Processing unfinished transaction with key %s', key)
-      await this._createAndExecuteActions(
-        transaction.newProductDraft,
-        transaction.backupProductDraft,
-        transaction.variants,
-        transaction.ctpProductToUpdate,
-        transactionObject
-      )
+      try {
+        await this._createAndExecuteActions(
+          transaction.newProductDraft,
+          transaction.backupProductDraft,
+          transaction.variants,
+          transaction.ctpProductToUpdate,
+          transactionObject
+        )
+        await this.transactionService.deleteTransaction(key)
+      } catch (e) {
+        this.logger.error('Could not process unfinished transaction', e)
+        throw e
+      }
     }
   }
 
@@ -147,7 +159,6 @@ export default class VariantReassignment {
 
     await this._createAndExecuteActions(productDraft, anonymizedProductDraft, backupVariants,
       ctpProductToUpdate, transaction, matchingProducts)
-
     await this.transactionService.deleteTransaction(transaction.key)
   }
 
@@ -169,7 +180,9 @@ export default class VariantReassignment {
         ctpProductToUpdate = productToUpdateCandidate
       else
         // ctpProductToUpdate has been deleted and not recreated with correct product type id
-        await this._createNewProduct(ctpProductToUpdate, productDraft.productType.id)
+        ctpProductToUpdate = await this._createNewProduct(
+          ctpProductToUpdate, productDraft.productType.id
+        )
     }
 
     // check if product types are the same for productDraft and CTP product to update
@@ -182,14 +195,18 @@ export default class VariantReassignment {
 
     matchingProducts
       = await this._removeVariantsFromMatchingProducts(backupVariants, matchingProducts)
+
     // when creating variant, also ensure about sameForAll attrs - Examples 9,10,11
     ctpProductToUpdate = await this._createVariantsInCtpProductToUpdate(backupVariants,
       productDraft, ctpProductToUpdate)
+
+
     // this is done only when variants are removed from ctpProductToUpdate
     if (anonymizedProductDraft) {
       await this._removeVariantsFromCtpProductToUpdate(anonymizedProductDraft, ctpProductToUpdate)
       await this.productService.createProduct(anonymizedProductDraft)
     }
+
     // e.g. Example 7
     await this._ensureSlugUniqueness(productDraft, matchingProducts)
   }
@@ -384,7 +401,12 @@ export default class VariantReassignment {
     return this.productService.getProductsBySkus(productDraftSkus)
   }
 
-  _createNewProduct () {
+  _createNewProduct (product, productTypeId) {
+    product.productType.id = productTypeId
+
+    const projection = this.productService.transformProductToProjection(product)
+    projection.productType.id = productTypeId
+    return this.productService.createProduct(projection)
   }
 
   /**
@@ -401,12 +423,13 @@ export default class VariantReassignment {
   }
 
   async _changeProductType (transaction, ctpProductToUpdate, productTypeId) {
-    await this._backupProductForProductTypeChange(transaction, ctpProductToUpdate)
-
     this.logger.debug(
-      'Changing productType of product "%s" to id "%s"',
+      'Changing productType of product %j with id "%s" to productType "%s"',
+      ctpProductToUpdate.masterData.current.name,
       ctpProductToUpdate.id, productTypeId
     )
+
+    await this._backupProductForProductTypeChange(transaction, ctpProductToUpdate)
 
     const updatedProduct = await this.productService.changeProductType(
       ctpProductToUpdate, productTypeId

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -66,7 +66,6 @@ export default class VariantReassignment {
         )
       }
 
-
     return Promise.resolve()
   }
 
@@ -193,13 +192,13 @@ export default class VariantReassignment {
         transaction, ctpProductToUpdate, draftProductType
       )
 
+    matchingProducts = matchingProducts.filter(product => product.id !== ctpProductToUpdate.id)
     matchingProducts
       = await this._removeVariantsFromMatchingProducts(backupVariants, matchingProducts)
 
     // when creating variant, also ensure about sameForAll attrs - Examples 9,10,11
     ctpProductToUpdate = await this._createVariantsInCtpProductToUpdate(backupVariants,
       productDraft, ctpProductToUpdate)
-
 
     // this is done only when variants are removed from ctpProductToUpdate
     if (anonymizedProductDraft) {
@@ -415,10 +414,10 @@ export default class VariantReassignment {
   async _backupProductForProductTypeChange (transactionObject, ctpProductToUpdate) {
     if (!transactionObject.ctpProductToUpdate) {
       const transactionKey = transactionObject.key
-      transactionObject = await this.transactionService.getTransaction(transactionKey)
-      const transactionValue = transactionObject.value
-      transactionValue.ctpProductToUpdate = ctpProductToUpdate
-      await this.transactionService.upsertTransactionByKey(transactionValue, transactionKey)
+      const transaction = await this.transactionService.getTransaction(transactionKey)
+      transaction.ctpProductToUpdate = ctpProductToUpdate
+
+      await this.transactionService.upsertTransactionByKey(transaction, transactionKey)
     }
   }
 
@@ -493,11 +492,10 @@ export default class VariantReassignment {
     return false
   }
 
-  async _removeVariantsFromCtpProductToUpdate (anonymizedProductDraft, ctpProductToUpdate) {
+  _removeVariantsFromCtpProductToUpdate (anonymizedProductDraft, ctpProductToUpdate) {
     const skusToRemove = this.productService.getProductDraftSkus(anonymizedProductDraft)
-
     this.logger.debug('Removing %d variants from ctpProductToUpdate', skusToRemove.length)
-    await this.productService.removeVariantsFromProduct(ctpProductToUpdate, skusToRemove)
+    return this.productService.removeVariantsFromProduct(ctpProductToUpdate, skusToRemove)
   }
 
   async _createVariantsInCtpProductToUpdate (backupVariants, productDraft, ctpProductToUpdate) {
@@ -543,11 +541,16 @@ export default class VariantReassignment {
       })
       return resultMap
     }, new Map())
+
     for (const variant of backupVariants) {
       const product = skuToProductMap.get(variant.sku)
       const actions = productToSkusToRemoveMap.get(product) || []
-      actions.push(variant.sku)
-      productToSkusToRemoveMap.set(product, actions)
+
+      // if there is a product from where we can delete variant..
+      if (product) {
+        actions.push(variant.sku)
+        productToSkusToRemoveMap.set(product, actions)
+      }
     }
 
     this.logger.debug('Removing variants from matching products')

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -6,7 +6,6 @@ import TransactionService from '../services/transaction-manager'
 export default class VariantReassignment {
 
   constructor (client, logger, options = {}, blackList = [], retainExistingAttributes = []) {
-    this.unfinishedTransactions = []
     this.firstRun = true
     this.customObjectService = null // build custom object service
     this.blackList = blackList
@@ -17,31 +16,93 @@ export default class VariantReassignment {
     this.transactionService = new TransactionService(logger, client)
   }
 
+  /**
+   * Take a list of product drafts and existing products matched by sku
+   *  - for every productDraft check if reassignment is needed
+   *  - if yes, create and process actions which will move variants across products
+   * @param productDrafts List of productDrafts
+   * @param existingProductProjections List of existing products matching by SKU
+   * @returns {Promise.<*>}
+   */
   async execute (productDrafts, existingProductProjections) {
-    this._processUnfinishedTransactions()
+    let products
 
-    const products
-      = await this.productService.fetchProductsFromProductProjections(existingProductProjections)
+    try {
+      if (this.firstRun)
+        await this._processUnfinishedTransactions()
+    } catch (e) {
+      return this._error('Could not process unfinished transactions', e)
+    }
+    this.firstRun = false
+
+    try {
+      products
+        = await this.productService.fetchProductsFromProductProjections(existingProductProjections)
+    } catch (e) {
+      return this._error('Error while fetching products for reassignment', e)
+    }
 
     const productDraftsForReassignment
       = this._selectProductDraftsForReassignment(productDrafts, products)
 
+    this.logger.debug(
+      'Filtered %d productDrafts for reassignment',
+      productDraftsForReassignment.length
+    )
+
     if (productDraftsForReassignment.length)
       for (const productDraft of productDraftsForReassignment)
-        await this._processProductDraft(productDraft, products)
+        try {
+          await this._processProductDraft(productDraft, products)
+        } catch (e) {
+          this.logger.error(
+            'Error while processing productDraft %j, processing unfinished transaction',
+            productDraft.name
+          )
+
+          await this._processUnfinishedTransactions()
+        }
+
+    return Promise.resolve()
   }
 
-  async _processUnfinishedTransactions () {
-    if (this.firstRun)
-      this.unfinishedTransactions = [] // API.getUnfinishedTransactions()
 
-    this.firstRun = false
-    for (const transaction of this.unfinishedTransactions)
+  /**
+   * Log error and return Promise.reject
+   * @param msg String with error description
+   * @param e Error object with details
+   * @return <Promise.reject>
+   * @private
+   */
+  _error (msg, e) {
+    this.logger.error(msg, e)
+    return Promise.reject(new Error(msg))
+  }
+
+  /**
+   * Load unfinished transactions from customObject and try to finish them
+   * @private
+   */
+  async _processUnfinishedTransactions () {
+    this.logger.debug('Loading unfinished transactions')
+    const unfinishedTransactions = await this.transactionService.getTransactions()
+
+    for (const transactionObject of unfinishedTransactions) {
+      const key = transactionObject.key
+      const transaction = transactionObject.value
+
+      this.logger.debug('Processing unfinished transaction with key %s', key)
       await this._createAndExecuteActions(transaction.newProductDraft,
         transaction.backupProductDraft, transaction.variants, transaction.ctpProductToUpdate)
+    }
   }
 
   async _processProductDraft (productDraft, products) {
+    this.logger.debug(
+      'Processing reassignment for productDraft with name %j',
+      productDraft.name
+    )
+
     const matchingProducts = await this._selectMatchingProducts(productDraft, products)
 
     if (matchingProducts.length === 0)
@@ -49,12 +110,19 @@ export default class VariantReassignment {
 
     // select using SLUG, etc..
     const ctpProductToUpdate = this._selectCtpProductToUpdate(productDraft, matchingProducts)
+    this.logger.debug('Selected ctpProductToUpdate with id "%s"', ctpProductToUpdate.id)
 
     // get variants and draft to backup
     const { matchingProductsVars: backupVariants, ctpProductToUpdateVars: variantsToProcess }
       = this._getRemovedVariants(productDraft, matchingProducts, ctpProductToUpdate)
+
     const anonymizedProductDraft
       = this._createProductDraftWithRemovedVariants(ctpProductToUpdate, variantsToProcess)
+
+    this.logger.debug(
+      'Will remove %d and reassign %d variants',
+      variantsToProcess.length, backupVariants.length
+    )
 
     // create a backup object
     const transaction
@@ -155,13 +223,11 @@ export default class VariantReassignment {
 
   _saveTransaction (actions) {
     const transactionKey = '' // productId + timestamp
-    const object = this.customObjectService.save({
+    this.customObjectService.save({
       container: 'commercetools-sync-unprocessed-product-reassignment-actions',
       key: transactionKey,
       actions
     })
-
-    this.unfinishedTransactions.push(object)
 
     return transactionKey
   }
@@ -294,9 +360,6 @@ export default class VariantReassignment {
     return this.productService.getProductsBySkus(productDraftSkus)
   }
 
-  _deleteTransaction () {
-  }
-
   _createNewProduct () {
   }
 
@@ -315,6 +378,12 @@ export default class VariantReassignment {
 
   async _changeProductType (transaction, ctpProductToUpdate, productTypeId) {
     await this._backupProductForProductTypeChange(transaction, ctpProductToUpdate)
+
+    this.logger.debug(
+      'Changing productType of product "%s" to id "%s"',
+      ctpProductToUpdate.id, productTypeId
+    )
+
     const updatedProduct = await this.productService.changeProductType(
       ctpProductToUpdate, productTypeId
     )
@@ -344,6 +413,10 @@ export default class VariantReassignment {
       this._isSlugConflicting(product, productDraftSlug)
     )
 
+    this.logger.debug(
+      'Anonymizing %d products because of duplicate slugs',
+      productsToAnonymize.length
+    )
     await Promise.map(productsToAnonymize, product =>
         this.productService.anonymizeCtpProduct(product)
       , { concurrency: 3 })
@@ -375,6 +448,8 @@ export default class VariantReassignment {
 
   async _removeVariantsFromCtpProductToUpdate (anonymizedProductDraft, ctpProductToUpdate) {
     const skusToRemove = this.productService.getProductDraftSkus(anonymizedProductDraft)
+
+    this.logger.debug('Removing %d variants from ctpProductToUpdate', skusToRemove.length)
     await this.productService.removeVariantsFromProduct(ctpProductToUpdate, skusToRemove)
   }
 
@@ -408,6 +483,8 @@ export default class VariantReassignment {
         images: variant.images,
         attributes: variant.attributes
       })
+
+    this.logger.debug('Updating ctpProductToUpdate with %d addVariant actions', actions.length)
     return this.productService.updateProduct(ctpProductToUpdate, actions)
   }
 
@@ -426,6 +503,7 @@ export default class VariantReassignment {
       productToSkusToRemoveMap.set(product, actions)
     }
 
+    this.logger.debug('Removing variants from matching products')
     return Promise.map(Array.from(productToSkusToRemoveMap), ([product, skus]) =>
         this.productService.removeVariantsFromProduct(product, skus),
       { concurrency: 3 })

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -203,7 +203,7 @@ export default class VariantReassignment {
     // this is done only when variants are removed from ctpProductToUpdate
     if (anonymizedProductDraft) {
       await this._removeVariantsFromCtpProductToUpdate(anonymizedProductDraft, ctpProductToUpdate)
-      await this.productService.createProduct(anonymizedProductDraft)
+      await this._ensureAnonymizedProductDraft(anonymizedProductDraft)
     }
 
     // e.g. Example 7
@@ -395,7 +395,12 @@ export default class VariantReassignment {
     if (products) {
       const skuToProductMap = this._createSkuToProductMap(products)
       const matchingProducts = productDraftSkus.map(sku => skuToProductMap.get(sku))
-      return _.uniq(matchingProducts)
+
+      // when there is a new non existing variant in product draft we will get undefined
+      // in matchingProducts because there is no existing product so with _.compact we
+      // will remove undefined value and work only with variants which are existing on API
+      // and should be reassigned
+      return _.uniq(_.compact(matchingProducts))
     }
     return this.productService.getProductsBySkus(productDraftSkus)
   }
@@ -406,6 +411,15 @@ export default class VariantReassignment {
     const projection = this.productService.transformProductToProjection(product)
     projection.productType.id = productTypeId
     return this.productService.createProduct(projection)
+  }
+
+  async _ensureAnonymizedProductDraft (anonymizedProductDraft) {
+    const { sku } = anonymizedProductDraft.masterVariant
+    const products = await this.productService.getProductsBySkus([sku])
+
+    // anonymizedProduct draft hasn't been created yet
+    if (!products.length)
+      await this.productService.createProduct(anonymizedProductDraft)
   }
 
   /**
@@ -463,6 +477,7 @@ export default class VariantReassignment {
       'Anonymizing %d products because of duplicate slugs',
       productsToAnonymize.length
     )
+
     await Promise.map(productsToAnonymize, product =>
         this.productService.anonymizeCtpProduct(product)
       , { concurrency: 3 })

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -56,16 +56,27 @@ export default class VariantReassignment {
           await this._processProductDraft(productDraft, products)
         } catch (e) {
           this.logger.error(
-            'Error while processing productDraft %j, processing unfinished transaction',
-            productDraft.name
+            'Error while processing productDraft %j, retrying.',
+            productDraft.name, e.toString()
           )
-
-          await this._processUnfinishedTransactions()
+          await this._handleProcessingError(productDraft, products)
         }
 
     return Promise.resolve()
   }
 
+  async _handleProcessingError (productDraft, products) {
+    const transactions = await this.transactionService.getTransactions()
+    const failedTransaction = transactions.find(transaction =>
+      _.isEqual(transaction.newProductDraft.name, productDraft.name)
+    )
+
+    return failedTransaction
+      // transaction was created but not finished, try to finish it
+      ? this._processUnfinishedTransactions(transactions)
+      // transaction was not created, try to process productDraft again
+      : this._processProductDraft(productDraft, products)
+  }
 
   /**
    * Log error and return Promise.reject
@@ -75,19 +86,20 @@ export default class VariantReassignment {
    * @private
    */
   _error (msg, e) {
+    const error = (e && e.message) || String(e)
     this.logger.error(msg, e)
-    return Promise.reject(new Error(msg))
+    return Promise.reject(new Error(`${msg} - ${error}`))
   }
 
   /**
    * Load unfinished transactions from customObject and try to finish them
    * @private
    */
-  async _processUnfinishedTransactions () {
+  async _processUnfinishedTransactions (transactions = null) {
     this.logger.debug('Loading unfinished transactions')
-    const unfinishedTransactions = await this.transactionService.getTransactions()
+    transactions = transactions || await this.transactionService.getTransactions()
 
-    for (const transactionObject of unfinishedTransactions) {
+    for (const transactionObject of transactions) {
       const key = transactionObject.key
       const transaction = transactionObject.value
 

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -6,6 +6,9 @@ import TransactionService from '../services/transaction-manager'
 export default class VariantReassignment {
 
   constructor (client, logger, options = {}, blackList = [], retainExistingAttributes = []) {
+    // When we run execute method it also fetch and process all unfinished transactions
+    // but only for the first time - this is ensured by firstRun variable which is set to false
+    // after first run
     this.firstRun = true
     this.customObjectService = null // build custom object service
     this.blackList = blackList
@@ -203,7 +206,7 @@ export default class VariantReassignment {
     // this is done only when variants are removed from ctpProductToUpdate
     if (anonymizedProductDraft) {
       await this._removeVariantsFromCtpProductToUpdate(anonymizedProductDraft, ctpProductToUpdate)
-      await this._ensureAnonymizedProductDraft(anonymizedProductDraft)
+      await this._ensureProductCreation(anonymizedProductDraft)
     }
 
     // e.g. Example 7
@@ -385,10 +388,8 @@ export default class VariantReassignment {
       const skuToProductMap = this._createSkuToProductMap(products)
       const matchingProducts = productDraftSkus.map(sku => skuToProductMap.get(sku))
 
-      // when there is a new non existing variant in product draft we will get undefined
-      // in matchingProducts because there is no existing product so with _.compact we
-      // will remove undefined value and work only with variants which are existing on API
-      // and should be reassigned
+      // When there are new variants in productDraft the matchingProducts will contain
+      // undefined values which we filter out using _.compact method
       return _.uniq(_.compact(matchingProducts))
     }
     return this.productService.getProductsBySkus(productDraftSkus)
@@ -402,13 +403,13 @@ export default class VariantReassignment {
     return this.productService.createProduct(projection)
   }
 
-  async _ensureAnonymizedProductDraft (anonymizedProductDraft) {
-    const { sku } = anonymizedProductDraft.masterVariant
-    const products = await this.productService.getProductsBySkus([sku])
+  async _ensureProductCreation (productDraft) {
+    const { sku } = productDraft.masterVariant
+    const existingProducts = await this.productService.getProductsBySkus([sku])
 
-    // anonymizedProduct draft hasn't been created yet
-    if (!products.length)
-      await this.productService.createProduct(anonymizedProductDraft)
+    // productDraft hasn't been created yet
+    if (!existingProducts.length)
+      await this.productService.createProduct(productDraft)
   }
 
   /**

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -261,17 +261,6 @@ export default class VariantReassignment {
     return products.find(p => p.masterData.staged.masterVariant.sku === masterVariantSku)
   }
 
-  _saveTransaction (actions) {
-    const transactionKey = '' // productId + timestamp
-    this.customObjectService.save({
-      container: 'commercetools-sync-unprocessed-product-reassignment-actions',
-      key: transactionKey,
-      actions
-    })
-
-    return transactionKey
-  }
-
   _selectProductDraftsForReassignment (productDrafts, ctpProducts) {
     const skuToProductMap = this._createSkuToProductMap(ctpProducts)
     return productDrafts.filter(productDraft =>

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -358,16 +358,19 @@ export default class VariantReassignment {
    * @private
    */
   _isSlugConflicting (product, productDraftSlug) {
-    const stagedSlug = product.masterData.staged.slug
-    const currentSlug = product.masterData.current.slug
-    const stagedDraftSlugs = _.merge({}, productDraftSlug, stagedSlug)
-    const currentDraftSlugs = _.merge({}, productDraftSlug, currentSlug)
     const productDraftSlugLength = Object.keys(productDraftSlug).length
-    const stagedSlugLength = Object.keys(stagedSlug).length
-    const currentSlugLength = Object.keys(currentSlug).length
 
-    return stagedSlugLength + productDraftSlugLength > Object.keys(stagedDraftSlugs).length
-      || currentSlugLength + productDraftSlugLength > Object.keys(currentDraftSlugs).length
+    // if at least one version has conflict in slugs, return true
+    for (const version of ['staged', 'current']) {
+      const slug = product.masterData[version].slug
+      const slugLength = Object.keys(slug).length
+      const stagedDraftSlugs = _.merge({}, productDraftSlug, slug)
+      const stagedDraftSlugsLength = Object.keys(stagedDraftSlugs).length
+
+      if (slugLength + productDraftSlugLength !== stagedDraftSlugsLength)
+        return true
+    }
+    return false
   }
 
   async _removeVariantsFromCtpProductToUpdate (anonymizedProductDraft, ctpProductToUpdate) {
@@ -426,7 +429,7 @@ export default class VariantReassignment {
     return Promise.map(Array.from(productToSkusToRemoveMap), ([product, skus]) =>
         this.productService.removeVariantsFromProduct(product, skus),
       { concurrency: 3 })
-      .then(result => _.compact(result))
+      .then(_.compact)
   }
 
 }

--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -57,8 +57,14 @@ export default class ProductManager {
       'reviewRatingStatistics'
     ]
 
+    const masterLevelFields = [
+      'published',
+      'hasStagedChanges'
+    ]
+
     const projection = product.masterData[staged ? 'staged' : 'current']
     _.merge(projection, _.pick(product, productLevelFields))
+    _.merge(projection, _.pick(product.masterData, masterLevelFields))
     return _.cloneDeep(projection)
   }
 
@@ -420,7 +426,6 @@ export default class ProductManager {
     const productProjection = this.transformProductToProjection(product)
 
     await this.deleteByProduct(productProjection)
-
     productProjection.productType.id = newProductTypeId
     return this.createProduct(productProjection)
   }

--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -62,7 +62,9 @@ export default class ProductManager {
       'hasStagedChanges'
     ]
 
-    const projection = product.masterData[staged ? 'staged' : 'current']
+    const projection = _.cloneDeep(
+      product.masterData[staged ? 'staged' : 'current']
+    )
     _.merge(projection, _.pick(product, productLevelFields))
     _.merge(projection, _.pick(product.masterData, masterLevelFields))
     return _.cloneDeep(projection)

--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -13,7 +13,7 @@ export default class ProductManager {
   }
 
   createProduct (product) {
-    this.logger.debug('Creating product', product)
+    this.logger.debug('Creating product: %j', product)
 
     return this.client.products
       .create(product)
@@ -41,6 +41,25 @@ export default class ProductManager {
       .byId(product.id)
       .update(request)
       .then(res => res.body)
+  }
+
+  transformProductToProjection (product, staged = true) {
+    const productLevelFields = [
+      'id',
+      'key',
+      'version',
+      'createdAt',
+      'catalogData',
+      'lastModifiedAt',
+      'productType',
+      'taxCategory',
+      'state',
+      'reviewRatingStatistics'
+    ]
+
+    const projection = product.masterData[staged ? 'staged' : 'current']
+    _.merge(projection, _.pick(product, productLevelFields))
+    return _.cloneDeep(projection)
   }
 
   async getProductsBySkus (skus) {
@@ -72,6 +91,19 @@ export default class ProductManager {
 
   getProductById (id) {
     return this.client.products
+      .byId(id)
+      .fetch()
+      .then(res => res.body)
+      .catch(err => (
+        err && err.body && err.body.statusCode === 404
+          ? Promise.resolve(undefined)
+          : Promise.reject(err)
+      ))
+  }
+
+  getProductProjectionById (id) {
+    return this.client.productProjections
+      .staged(true)
       .byId(id)
       .fetch()
       .then(res => res.body)
@@ -384,15 +416,8 @@ export default class ProductManager {
   }
 
   async changeProductType (product, newProductTypeId) {
-    if (product.masterData.published)
-      await this._unpublishProduct(product)
-
-    // fetch from product projection because it has same structure
-    // as product draft. It's easier for product creation later in the process
-    const { body: productProjection } = await this.client.productProjections
-      .staged(true)
-      .byId(product.id)
-      .fetch()
+    this.logger.debug('Changing productType', product.id)
+    const productProjection = await this.getProductProjectionById(product.id)
 
     await this.deleteByProduct(productProjection)
 
@@ -408,8 +433,9 @@ export default class ProductManager {
   isProductsSame (ctpProduct1, ctpProduct2) {
     if (ctpProduct1.id === ctpProduct2.id)
       return true
+
     return ctpProduct1.productType.id === ctpProduct2.productType.id
-      && _.deepEqual(ctpProduct1.masterData.staged.slug, ctpProduct2.masterData.staged.slug)
+      && _.isEqual(ctpProduct1.masterData.staged.slug, ctpProduct2.masterData.staged.slug)
   }
 
   async _unpublishProduct (product) {

--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -417,7 +417,7 @@ export default class ProductManager {
 
   async changeProductType (product, newProductTypeId) {
     this.logger.debug('Changing productType', product.id)
-    const productProjection = await this.getProductProjectionById(product.id)
+    const productProjection = this.transformProductToProjection(product)
 
     await this.deleteByProduct(productProjection)
 

--- a/lib/services/transaction-manager.js
+++ b/lib/services/transaction-manager.js
@@ -49,6 +49,7 @@ export default class TransactionManager {
   }
 
   async deleteTransaction (key) {
+    this.logger.debug('Removing transaction with key "%s"', key)
     const transaction = await this.getTransaction(key)
 
     if (transaction)

--- a/lib/services/transaction-manager.js
+++ b/lib/services/transaction-manager.js
@@ -17,11 +17,11 @@ export default class TransactionManager {
     return this.upsertTransactionByKey(transaction, `${+new Date()}`)
   }
 
-  upsertTransactionByKey (transaction, key) {
+  upsertTransactionByKey (value, key) {
     const customObject = {
       container: constants.TRANSACTION_CONTAINER,
       key,
-      value: transaction
+      value
     }
 
     return this.client.customObjects
@@ -29,7 +29,12 @@ export default class TransactionManager {
       .then(res => res.body)
   }
 
-  getTransaction (key) {
+  async getTransaction (key) {
+    const transactionObject = await this.getTransactionObject(key)
+    return transactionObject && transactionObject.value
+  }
+
+  getTransactionObject (key) {
     const predicate = `container = "${constants.TRANSACTION_CONTAINER}"`
       + ` AND key = "${key}"`
 
@@ -50,7 +55,7 @@ export default class TransactionManager {
 
   async deleteTransaction (key) {
     this.logger.debug('Removing transaction with key "%s"', key)
-    const transaction = await this.getTransaction(key)
+    const transaction = await this.getTransactionObject(key)
 
     if (transaction)
       return this.client.customObjects

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "eslint-config-airbnb": "^15.0.0",
     "eslint-config-commercetools": "^6.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.5.1",
     "istanbul": "^0.4.5",
     "mocha": "^4.1.0",
     "mversion": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "dependencies": {
     "bluebird": "^3.4.7",
     "bunyan": "^1.8.12",
+    "install": "^0.10.2",
     "lodash": "^4.17.4",
+    "npm": "^5.6.0",
     "shortid": "^2.2.8",
     "sphere-node-sdk": "^1.20.0",
     "sphere-node-utils": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "npm": "^5.6.0",
     "shortid": "^2.2.8",
     "sphere-node-sdk": "^1.20.0",
-    "sphere-node-utils": "^0.9.1",
+    "sphere-node-utils": "^0.9.2",
     "utils-error-to-json": "^1.0.0",
     "uuid": "^3.0.1"
   },
@@ -60,13 +60,13 @@
     "eslint-config-commercetools": "^6.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.0.1",
+    "eslint-plugin-react": "^7.5.1",
     "istanbul": "^0.4.5",
-    "mocha": "^4.0.1",
+    "mocha": "^4.1.0",
     "mversion": "^1.10.1",
-    "nyc": "^11.3.0",
+    "nyc": "^11.4.1",
     "precommit-hook-eslint": "^3.0.0",
     "rimraf": "^2.5.4",
-    "sinon": "^4.1.2"
+    "sinon": "^4.1.4"
   }
 }

--- a/spec/integration/error-cases/reassignment-error.spec.js
+++ b/spec/integration/error-cases/reassignment-error.spec.js
@@ -16,6 +16,7 @@ describe('Reassignment error', () => {
   before(async () => {
     ctpClient = await utils.createClient()
   })
+
   beforeEach(async () => {
     logger = utils.createLogger(__filename)
     spyError = sinon.spy(logger, 'error')
@@ -79,6 +80,51 @@ describe('Reassignment error', () => {
       expect(spyError.callCount).to.equal(1)
       expect(spyError.lastCall.args[1].toString()).to.contain('test error')
 
+      return Promise.resolve()
+    }
+  })
+
+  it('should retry when reassignment fails before creating transaction', async () => {
+    const spyUnfinished = sinon.spy(reassignment, '_processUnfinishedTransactions')
+    const spyProductDraft = sinon.spy(reassignment, '_processProductDraft')
+
+    sinon.stub(reassignment, '_selectMatchingProducts')
+      .onFirstCall().rejects('test error')
+      .callThrough()
+
+    await reassignment.execute([productDraft], [product1, product2])
+
+    expect(spyError.callCount).to.equal(1)
+    expect(spyError.firstCall.args[0])
+      .to.contain('Error while processing productDraft')
+    expect(spyError.firstCall.args[2])
+      .to.contain('test error')
+
+    expect(spyUnfinished.callCount).to.equal(1)
+    expect(spyProductDraft.callCount).to.equal(2)
+
+    const { body: { results } } = await utils.getProductsBySkus(['1', '2', '3', '4'], ctpClient)
+    expect(results).to.have.lengthOf(3)
+    const backupProduct = results.find(product => product.masterVariant.sku === '4')
+    expect(backupProduct).to.be.an('object')
+    expect(backupProduct.variants).to.have.lengthOf(0)
+    const updatedProduct = results.find(product => product.masterVariant.sku === '1')
+    expect(updatedProduct.variants[0].sku).to.equal(productDraft.variants[0].sku)
+
+    const anonymizedProduct = results.find(product => product.masterVariant.sku === '2')
+    expect(anonymizedProduct).to.be.an('object')
+    expect(anonymizedProduct.slug).to.haveOwnProperty('ctsd')
+  })
+
+  it('should retry only once when reassignment fails before creating transaction', async () => {
+    sinon.stub(reassignment, '_selectMatchingProducts').rejects('test error')
+
+    try {
+      await reassignment.execute([productDraft], [product1, product2])
+      return Promise.reject('Should throw an error')
+    } catch (e) {
+      expect(e.toString()).to.contain('test error')
+      expect(spyError.callCount).to.equal(1)
       return Promise.resolve()
     }
   })

--- a/spec/integration/error-cases/reassignment-error.spec.js
+++ b/spec/integration/error-cases/reassignment-error.spec.js
@@ -1,0 +1,85 @@
+import { expect } from 'chai'
+import _ from 'lodash'
+import sinon from 'sinon'
+import * as utils from '../../utils/helper'
+import VariantReassignment from '../../../lib/runner/variant-reassignment'
+
+describe('Reassignment error', () => {
+  let ctpClient
+  let product1
+  let product2
+  let productDraft
+  let reassignment
+  let logger
+  let spyError
+
+  before(async () => {
+    ctpClient = await utils.createClient()
+  })
+  beforeEach(async () => {
+    logger = utils.createLogger(__filename)
+    spyError = sinon.spy(logger, 'error')
+    reassignment = new VariantReassignment(ctpClient, logger)
+
+    await utils.deleteResourcesAll(ctpClient, logger)
+    const products = await utils.createCtpProducts([['1', '2'], ['3', '4']], ctpClient)
+    product1 = _.find(products, ['masterVariant.sku', '1'])
+    product2 = _.find(products, ['masterVariant.sku', '3'])
+
+    productDraft = {
+      productType: {
+        id: product1.productType.id
+      },
+      name: {
+        en: 'Sample product1'
+      },
+      slug: {
+        en: 'sample-product1'
+      },
+      masterVariant: {
+        sku: '1'
+      },
+      variants: [
+        {
+          sku: '3'
+        }
+      ]
+    }
+  })
+
+  after(() =>
+    utils.deleteResourcesAll(ctpClient, logger)
+  )
+
+  it('should fail when process unfinished transaction fails', async () => {
+    sinon.stub(reassignment.transactionService, 'getTransactions')
+      .rejects('test error')
+
+    try {
+      await reassignment.execute([productDraft], [product1, product2])
+      return Promise.reject('Should throw an error')
+    } catch (e) {
+      expect(e.toString()).to.contain('Could not process unfinished transactions')
+      expect(spyError.callCount).to.equal(1)
+      expect(spyError.lastCall.args[1].toString()).to.contain('test error')
+
+      return Promise.resolve()
+    }
+  })
+
+  it('should fail when process can\'t load existing products', async () => {
+    sinon.stub(reassignment.productService, 'fetchProductsFromProductProjections')
+      .rejects('test error')
+
+    try {
+      await reassignment.execute([productDraft], [product1, product2])
+      return Promise.reject('Should throw an error')
+    } catch (e) {
+      expect(e.toString()).to.contain('Error while fetching products for reassignment')
+      expect(spyError.callCount).to.equal(1)
+      expect(spyError.lastCall.args[1].toString()).to.contain('test error')
+
+      return Promise.resolve()
+    }
+  })
+})

--- a/spec/integration/product-manager.spec.js
+++ b/spec/integration/product-manager.spec.js
@@ -174,7 +174,6 @@ describe('ProductManager', () => {
 
       product = await productService.publishProduct(product)
       const newProduct = await productService.changeProductType(product, productType2.id)
-
       expect(newProduct).to.be.an('object')
       expect(newProduct.productType.id).to.equal(productType2.id)
       expect(new Date(newProduct.createdAt)).to.be.above(new Date(product.createdAt))

--- a/spec/utils/helper.js
+++ b/spec/utils/helper.js
@@ -219,6 +219,8 @@ export async function deleteResourcesAll (client, _logger) {
     client.channels,
     client.customObjects
   ]
+
+  await unpublishAllProducts(client)
   for (const resource of resourcesToDelete)
     await deleteResource(resource, '', _logger)
 }


### PR DESCRIPTION
Hello @lojzatran - this PR is finally ready for your review. I took one example and using `sinon.stub` I am returning an error in several places where it can break.

The recovery logic for is following
 - if the reassignment process throw an error check if there was created a transaction
   - if yes, process it as an unfinished transaction
   - if no, process product draft normally

This recovery process s there only once for every productDraft so if it throws an error during recovery, the whole reassignment fails. 

Resolves #3 
  