### PR TITLE
 #2 Refactor log messages

### DIFF
--- a/dist/runner/variant-reassignment.js
+++ b/dist/runner/variant-reassignment.js
@@ -40,6 +40,10 @@ var _regenerator = require('babel-runtime/regenerator');
 
 var _regenerator2 = _interopRequireDefault(_regenerator);
 
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
+
 var _getIterator2 = require('babel-runtime/core-js/get-iterator');
 
 var _getIterator3 = _interopRequireDefault(_getIterator2);
@@ -156,7 +160,7 @@ var VariantReassignment = function () {
                 productDraftsForReassignment = this._selectProductDraftsForReassignment(productDrafts, products);
 
 
-                this.logger.debug('Filtered %d productDrafts for reassignment', productDraftsForReassignment.length);
+                this.logger.debug('Filtered ' + productDraftsForReassignment.length + ' productDrafts for reassignment');
 
                 isReassignmentRequired = productDraftsForReassignment.length;
 
@@ -193,14 +197,14 @@ var VariantReassignment = function () {
                 _context.t2 = _context['catch'](31);
                 error = _context.t2 instanceof Error ? (0, _utilsErrorToJson2.default)(_context.t2) : _context.t2;
 
-                this.logger.error('Error while processing productDraft %j, retrying.', productDraft.name, error);
+                this.logger.error('Error while processing productDraft ' + (0, _stringify2.default)(productDraft.name) + ', retrying.', error);
                 _context.next = 43;
                 return this._handleProcessingError(productDraft, products);
 
               case 43:
                 _context.prev = 43;
 
-                this.logger.debug('Finished processing of productDraft with name %j', productDraft.name);
+                this.logger.debug('Finished processing of productDraft with name ' + (0, _stringify2.default)(productDraft.name));
                 return _context.finish(43);
 
               case 46:
@@ -363,7 +367,7 @@ var VariantReassignment = function () {
                 key = transactionObject.key, transaction = transactionObject.value;
 
 
-                this.logger.debug('Processing unfinished transaction with key %s', key);
+                this.logger.debug('Processing unfinished transaction with key ' + key);
                 _context3.prev = 14;
                 _context3.next = 17;
                 return this._createAndExecuteActions(transaction.newProductDraft, transaction.backupProductDraft, transaction.variants, transaction.ctpProductToUpdate, transactionObject);
@@ -447,7 +451,7 @@ var VariantReassignment = function () {
           while (1) {
             switch (_context4.prev = _context4.next) {
               case 0:
-                this.logger.debug('Processing reassignment for productDraft with name %j', productDraft.name);
+                this.logger.debug('Processing reassignment for productDraft with name ' + (0, _stringify2.default)(productDraft.name));
 
                 _context4.next = 3;
                 return this._selectMatchingProducts(productDraft, products);
@@ -467,14 +471,14 @@ var VariantReassignment = function () {
                 // select using SLUG, etc..
                 ctpProductToUpdate = this._selectCtpProductToUpdate(productDraft, matchingProducts);
 
-                this.logger.debug('Selected ctpProductToUpdate with id "%s"', ctpProductToUpdate.id);
+                this.logger.debug('Selected ctpProductToUpdate with id "' + ctpProductToUpdate.id + '"');
 
                 // get variants and draft to backup
                 _getRemovedVariants2 = this._getRemovedVariants(productDraft, matchingProducts, ctpProductToUpdate), backupVariants = _getRemovedVariants2.matchingProductsVars, variantsToProcess = _getRemovedVariants2.ctpProductToUpdateVars;
                 anonymizedProductDraft = this._createProductDraftWithRemovedVariants(ctpProductToUpdate, variantsToProcess);
 
 
-                this.logger.debug('Will remove %d and reassign %d variants', variantsToProcess.length, backupVariants.length);
+                this.logger.debug('Will remove ' + variantsToProcess.length + ' and reassign ' + backupVariants.length + ' variants');
 
                 // create a backup object
                 _context4.next = 13;
@@ -1076,7 +1080,7 @@ var VariantReassignment = function () {
           while (1) {
             switch (_context8.prev = _context8.next) {
               case 0:
-                this.logger.debug('Changing productType of product %j with id "%s" to productType "%s"', ctpProductToUpdate.masterData.current.name, ctpProductToUpdate.id, productTypeId);
+                this.logger.debug('Changing productType of product ' + +((0, _stringify2.default)(ctpProductToUpdate.masterData.current.name) + ' with id ') + ('"' + ctpProductToUpdate.id + '" to productType "' + productTypeId + '"'));
 
                 _context8.next = 3;
                 return this._backupProductForProductTypeChange(transaction, ctpProductToUpdate);
@@ -1171,7 +1175,7 @@ var VariantReassignment = function () {
                 });
 
 
-                this.logger.debug('Anonymizing %d products because of duplicate slugs', productsToAnonymize.length);
+                this.logger.debug('Anonymizing ' + productsToAnonymize.length + ' products because of duplicate slugs');
 
                 _context10.next = 5;
                 return _bluebird2.default.map(productsToAnonymize, function (product) {
@@ -1349,7 +1353,7 @@ var VariantReassignment = function () {
                 return _context12.finish(21);
 
               case 29:
-                this.logger.debug('Updating ctpProductToUpdate with %d addVariant actions', actions.length);
+                this.logger.debug('Updating ctpProductToUpdate with ' + actions.length + ' addVariant actions');
                 return _context12.abrupt('return', this.productService.updateProduct(ctpProductToUpdate, actions));
 
               case 31:

--- a/dist/runner/variant-reassignment.js
+++ b/dist/runner/variant-reassignment.js
@@ -1080,7 +1080,7 @@ var VariantReassignment = function () {
           while (1) {
             switch (_context8.prev = _context8.next) {
               case 0:
-                this.logger.debug('Changing productType of product ' + +((0, _stringify2.default)(ctpProductToUpdate.masterData.current.name) + ' with id ') + ('"' + ctpProductToUpdate.id + '" to productType "' + productTypeId + '"'));
+                this.logger.debug('Changing productType of product ' + ((0, _stringify2.default)(ctpProductToUpdate.masterData.current.name) + ' with id ') + ('"' + ctpProductToUpdate.id + '" to productType "' + productTypeId + '"'));
 
                 _context8.next = 3;
                 return this._backupProductForProductTypeChange(transaction, ctpProductToUpdate);

--- a/dist/services/product-manager.js
+++ b/dist/services/product-manager.js
@@ -87,7 +87,7 @@ var ProductManager = function () {
   (0, _createClass3.default)(ProductManager, [{
     key: 'createProduct',
     value: function createProduct(product) {
-      this.logger.debug('Creating product: %j', product);
+      this.logger.debug('Creating product: ' + product);
 
       return this.client.products.create(product).then(function (res) {
         return res.body;

--- a/dist/services/product-manager.js
+++ b/dist/services/product-manager.js
@@ -16,10 +16,6 @@ var _keys = require('babel-runtime/core-js/object/keys');
 
 var _keys2 = _interopRequireDefault(_keys);
 
-var _stringify = require('babel-runtime/core-js/json/stringify');
-
-var _stringify2 = _interopRequireDefault(_stringify);
-
 var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
 
 var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
@@ -39,6 +35,10 @@ var _regenerator2 = _interopRequireDefault(_regenerator);
 var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
 
 var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
+
+var _stringify = require('babel-runtime/core-js/json/stringify');
+
+var _stringify2 = _interopRequireDefault(_stringify);
 
 var _map = require('babel-runtime/core-js/map');
 
@@ -87,7 +87,7 @@ var ProductManager = function () {
   (0, _createClass3.default)(ProductManager, [{
     key: 'createProduct',
     value: function createProduct(product) {
-      this.logger.debug('Creating product: ' + product);
+      this.logger.debug('Creating product: ' + (0, _stringify2.default)(product));
 
       return this.client.products.create(product).then(function (res) {
         return res.body;

--- a/dist/services/transaction-manager.js
+++ b/dist/services/transaction-manager.js
@@ -121,7 +121,7 @@ var TransactionManager = function () {
           while (1) {
             switch (_context2.prev = _context2.next) {
               case 0:
-                this.logger.debug('Removing transaction with key "%s"', key);
+                this.logger.debug('Removing transaction with key "' + key + '"');
                 _context2.next = 3;
                 return this.getTransactionObject(key);
 

--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -48,8 +48,7 @@ export default class VariantReassignment {
       = this._selectProductDraftsForReassignment(productDrafts, products)
 
     this.logger.debug(
-      'Filtered %d productDrafts for reassignment',
-      productDraftsForReassignment.length
+      `Filtered ${productDraftsForReassignment.length} productDrafts for reassignment`
     )
 
     const isReassignmentRequired = productDraftsForReassignment.length
@@ -62,14 +61,13 @@ export default class VariantReassignment {
         } catch (e) {
           const error = e instanceof Error ? errorToJson(e) : e
           this.logger.error(
-            'Error while processing productDraft %j, retrying.',
-            productDraft.name, error
+            `Error while processing productDraft ${JSON.stringify(productDraft.name)}, retrying.`,
+            error
           )
           await this._handleProcessingError(productDraft, products)
         } finally {
           this.logger.debug(
-            'Finished processing of productDraft with name %j',
-            productDraft.name
+            `Finished processing of productDraft with name ${JSON.stringify(productDraft.name)}`
           )
         }
       return true
@@ -116,7 +114,7 @@ export default class VariantReassignment {
     for (const transactionObject of transactions) {
       const { key, value: transaction } = transactionObject
 
-      this.logger.debug('Processing unfinished transaction with key %s', key)
+      this.logger.debug(`Processing unfinished transaction with key ${key}`)
       try {
         await this._createAndExecuteActions(
           transaction.newProductDraft,
@@ -136,8 +134,7 @@ export default class VariantReassignment {
 
   async _processProductDraft (productDraft, products) {
     this.logger.debug(
-      'Processing reassignment for productDraft with name %j',
-      productDraft.name
+      `Processing reassignment for productDraft with name ${JSON.stringify(productDraft.name)}`
     )
 
     const matchingProducts = await this._selectMatchingProducts(productDraft, products)
@@ -147,7 +144,7 @@ export default class VariantReassignment {
 
     // select using SLUG, etc..
     const ctpProductToUpdate = this._selectCtpProductToUpdate(productDraft, matchingProducts)
-    this.logger.debug('Selected ctpProductToUpdate with id "%s"', ctpProductToUpdate.id)
+    this.logger.debug(`Selected ctpProductToUpdate with id "${ctpProductToUpdate.id}"`)
 
     // get variants and draft to backup
     const { matchingProductsVars: backupVariants, ctpProductToUpdateVars: variantsToProcess }
@@ -157,8 +154,7 @@ export default class VariantReassignment {
       = this._createProductDraftWithRemovedVariants(ctpProductToUpdate, variantsToProcess)
 
     this.logger.debug(
-      'Will remove %d and reassign %d variants',
-      variantsToProcess.length, backupVariants.length
+      `Will remove ${variantsToProcess.length} and reassign ${backupVariants.length} variants`
     )
 
     // create a backup object
@@ -486,9 +482,9 @@ export default class VariantReassignment {
 
   async _changeProductType (transaction, ctpProductToUpdate, productTypeId) {
     this.logger.debug(
-      'Changing productType of product %j with id "%s" to productType "%s"',
-      ctpProductToUpdate.masterData.current.name,
-      ctpProductToUpdate.id, productTypeId
+      `Changing productType of product `
+      + `${JSON.stringify(ctpProductToUpdate.masterData.current.name)} with id `
+      + `"${ctpProductToUpdate.id}" to productType "${productTypeId}"`
     )
 
     await this._backupProductForProductTypeChange(transaction, ctpProductToUpdate)
@@ -523,8 +519,7 @@ export default class VariantReassignment {
     )
 
     this.logger.debug(
-      'Anonymizing %d products because of duplicate slugs',
-      productsToAnonymize.length
+      `Anonymizing ${productsToAnonymize.length} products because of duplicate slugs`
     )
 
     await Promise.map(productsToAnonymize, product =>
@@ -602,7 +597,7 @@ export default class VariantReassignment {
         attributes: variant.attributes
       })
 
-    this.logger.debug('Updating ctpProductToUpdate with %d addVariant actions', actions.length)
+    this.logger.debug(`Updating ctpProductToUpdate with ${actions.length} addVariant actions`)
     return this.productService.updateProduct(ctpProductToUpdate, actions)
   }
 

--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -17,7 +17,7 @@ export default class ProductManager {
   }
 
   createProduct (product) {
-    this.logger.debug('Creating product: %j', product)
+    this.logger.debug(`Creating product: ${JSON.stringify(product)}`)
 
     return this.client.products
       .create(product)

--- a/lib/services/transaction-manager.js
+++ b/lib/services/transaction-manager.js
@@ -57,7 +57,7 @@ export default class TransactionManager {
   }
 
   async deleteTransaction (key) {
-    this.logger.debug('Removing transaction with key "%s"', key)
+    this.logger.debug(`Removing transaction with key "${key}"`)
     const transaction = await this.getTransactionObject(key)
 
     if (transaction)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2017": "^6.24.1",
+    "babel-runtime": "^6.26.0",
     "bluebird": "^3.4.7",
     "bunyan": "^1.8.12",
     "install": "^0.10.2",

--- a/spec/integration/error-cases/reassignment-error.spec.js
+++ b/spec/integration/error-cases/reassignment-error.spec.js
@@ -136,7 +136,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     expect(spyUnfinished.callCount).to.equal(1)
@@ -168,7 +168,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     return checkResult()
@@ -189,7 +189,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     const { body: { results } } = await utils.getProductsBySkus(['1', '2', '3', '4'], ctpClient)
@@ -213,7 +213,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     const { body: { results } } = await utils.getProductsBySkus(['1', '2', '3', '4'], ctpClient)
@@ -237,7 +237,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     const { body: { results } } = await utils.getProductsBySkus(['1', '2', '3', '4'], ctpClient)
@@ -257,7 +257,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     return checkResult()
@@ -273,7 +273,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     return checkResult()
@@ -289,7 +289,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     return checkResult()
@@ -305,7 +305,7 @@ describe('Reassignment error', () => {
     expect(spyError.callCount).to.equal(1)
     expect(spyError.firstCall.args[0])
       .to.contain('Error while processing productDraft')
-    expect(spyError.firstCall.args[2].name)
+    expect(spyError.firstCall.args[1].name)
       .to.contain('test error')
 
     return checkResult()


### PR DESCRIPTION
There is a problem when running reassignment from `sphere-product-import` module. We are using there some logger which does not accept messages with `%s/j/d` notation so I inserted values directly to log message