### PR TITLE
#79 skip reassignment when there are no matching products found

### DIFF
--- a/lib/runner/variant-reassignment.js
+++ b/lib/runner/variant-reassignment.js
@@ -190,6 +190,10 @@ export default class VariantReassignment {
 
       const matchingProducts = await this._selectMatchingProducts(productDraft, products)
 
+      if (matchingProducts.length === 0) {
+        this.logger.warn(`No matching products for ${JSON.stringify(productDraft)}`)
+        return
+      }
       // select using SLUG, etc..
       const ctpProductToUpdate = this._selectCtpProductToUpdate(productDraft, matchingProducts)
       log(`Selected ctpProductToUpdate with id "${ctpProductToUpdate.id}"`)


### PR DESCRIPTION
Fixes https://github.com/commercetools/commercetools-node-variant-reassignment/issues/79