### PR TITLE
Do not add multiple anonymization IDs

### DIFF
--- a/lib/services/product-manager.js
+++ b/lib/services/product-manager.js
@@ -316,18 +316,28 @@ export default class ProductManager {
   /**
    * Method will take a product with variants which should be anonymized.
    * It will modify slug, key and name so the product can be created without
-   * issues with duplicate fields
+   * issues with duplicate fields.
+   * If it was anonymized before it will only replace old salt with the new one.
+   *
    * @param product productDraft
    */
   getAnonymizedProductDraft (product) {
     const salt = this._getSalt()
+    const oldAnonymizationId = product.slug[constant.PRODUCT_ANONYMIZE_SLUG_KEY]
 
     // make all languages in slug unique
     for (const lang in product.slug) // eslint-disable-line guard-for-in
-      product.slug[lang] += `-${salt}`
+      if (oldAnonymizationId)
+        product.slug[lang] = product.slug[lang].replace(oldAnonymizationId, salt)
+      else
+        product.slug[lang] += `-${salt}`
 
     if (product.key)
-      product.key += `-${salt}`
+      if (oldAnonymizationId)
+        product.key = product.key.replace(oldAnonymizationId, salt)
+      else
+        product.key += `-${salt}`
+
     product.slug[constant.PRODUCT_ANONYMIZE_SLUG_KEY] = salt
 
     return product

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-node-variant-reassignment",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commercetools-node-variant-reassignment",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Node.js utility which complements product sync/import process by automatic conflicts resolution and reassignment of variants from one product to another",
   "license": "MIT",
   "homepage": "https://github.com/commercetools/commercetools-node-variant-reassignment",

--- a/spec/integration/runner/variant-reassignment-example-16.1.spec.js
+++ b/spec/integration/runner/variant-reassignment-example-16.1.spec.js
@@ -1,0 +1,119 @@
+import { expect } from 'chai'
+import { find } from 'lodash'
+
+import * as utils from '../../utils/helper'
+import VariantReassignment from '../../../lib/runner/variant-reassignment'
+import { PRODUCT_ANONYMIZE_SLUG_KEY } from '../../../lib/constants'
+
+/* eslint-disable max-len */
+/**
+ * +------------------------------------+--------------------------------------+--------------------+------------------------------------------------------------+
+ * | Product draft                      | CTP product                          | After reassignment | CTP product                                                |
+ * +------------------------------------+--------------------------------------+--------------------+------------------------------------------------------------+
+ * | Product:                           | Product:                             |                    | Product id1 only with masterVariant sku1                   |
+ * | slug: { en: "bike" }               | id: 1                                |    Reassignment    | New anonymized product with sku2, sku3                     |
+ * | masterVariant: { sku: "red-bike" } | slug: { en: "test1" }                |        #1          |                                                            |
+ * |                                    | masterVariant: { sku: "sku1" }       |                    |                                                            |
+ * |                                    | variant SKUs: ['sku2', 'sku3']       |                    |                                                            |
+ * +------------------------------------+--------------------------------------+--------------------+------------------------------------------------------------+
+ * |                                    |                                      |                    | Product id1 only with masterVariant sku1                   |
+ * |                                    |                                      |    Reassignment    | New product with sku2                                      |
+ * |                                    |                                      |        #2          | Anonymized product with sku3 and only one anonymization id |
+ * |                                    |                                      |                    |                                                            |
+ * +------------------------------------+--------------------------------------+--------------------+------------------------------------------------------------+
+ */
+/* eslint-enable max-len */
+describe('Variant reassignment - product anonymization', () => {
+  let ctpClient
+  let product
+  const logger = utils.createLogger(__filename)
+  const variantSkus = ['sku1', 'sku2', 'sku3']
+
+  before(async () => {
+    ctpClient = await utils.createClient();
+    [product] = await utils.createCtpProducts([variantSkus], ctpClient, (pD) => {
+      pD.slug = { en: 'test1' }
+    })
+  })
+
+  after(() =>
+    utils.deleteResourcesAll(ctpClient, logger)
+  )
+
+  it('only one anonymization id when removing multiple variants one by one', async () => {
+    // Reassignment #1
+    const reassignment = new VariantReassignment(ctpClient, logger)
+    const { statistics: stats1 } = await reassignment.execute([{
+      productType: {
+        id: product.productType.id
+      },
+      name: product.name,
+      slug: product.slug,
+      masterVariant: product.masterVariant
+    }])
+
+    utils.expectStatistics(stats1, 1, 0, 1, 1)
+    expect(stats1.processedSkus).to.be.an('array')
+    expect(stats1.processedSkus[0]).to.equal('sku1')
+
+    // Reassignment #1 result
+    const { body: { results } } = await utils.getProductsBySkus(variantSkus, ctpClient)
+    expect(results).to.have.lengthOf(2)
+
+    const originalProduct = find(results, ['masterVariant.sku', 'sku1'])
+    const anonymizedProduct = find(results, ['masterVariant.sku', 'sku2'])
+
+    expect(originalProduct.slug[PRODUCT_ANONYMIZE_SLUG_KEY]).to.be.an('undefined')
+    expect(originalProduct.variants).to.have.length(0)
+
+    const reassignment1AnonymizationId = anonymizedProduct.slug[PRODUCT_ANONYMIZE_SLUG_KEY]
+
+    expect(reassignment1AnonymizationId).to.be.a('string')
+    expect(anonymizedProduct.variants).to.have.length(1)
+    expect(anonymizedProduct.masterVariant.sku).to.equal('sku2')
+    expect(anonymizedProduct.variants[0].sku).to.equal('sku3')
+    expect(anonymizedProduct.slug.en).to.contain(reassignment1AnonymizationId)
+
+
+    // Reassignment #2
+    const reassignment2 = new VariantReassignment(ctpClient, logger)
+    const { statistics: stats2 } = await reassignment2.execute([{
+      productType: {
+        id: product.productType.id
+      },
+      name: { en: `${product.name.en}-1` },
+      slug: { en: `${product.slug.en}-1` },
+      masterVariant: { sku: anonymizedProduct.masterVariant.sku }
+    }])
+
+    utils.expectStatistics(stats1, 1, 0, 1, 1)
+    expect(stats2.processedSkus).to.be.an('array')
+    expect(stats2.processedSkus[0]).to.equal('sku2')
+
+    // Reassignment #2 result
+    const { body: { results: results2 } } = await utils.getProductsBySkus(variantSkus, ctpClient)
+    expect(results2).to.have.lengthOf(3)
+
+    const originalProduct2 = find(results2, ['masterVariant.sku', 'sku1'])
+    const updatedProduct = find(results2, ['masterVariant.sku', 'sku2'])
+    const anonymizedProduct2 = find(results2, ['masterVariant.sku', 'sku3'])
+
+    // original product should not be changed by second reassignment
+    expect(originalProduct2.version).to.equal(originalProduct.version)
+
+    // updated product should have only one variant now
+    expect(updatedProduct.variants).to.have.length(0)
+    // slug should not be changed - it should be done later by product importer
+    expect(updatedProduct.slug[PRODUCT_ANONYMIZE_SLUG_KEY]).to.equal(reassignment1AnonymizationId)
+    expect(updatedProduct.slug.en).to.contain(reassignment1AnonymizationId)
+
+    const reassignment2AnonymizationId = anonymizedProduct2.slug[PRODUCT_ANONYMIZE_SLUG_KEY]
+
+    // new anonymized product should have only one variant
+    expect(anonymizedProduct2.variants).to.have.length(0)
+    // and slug should not contain anonymization id from previous reassignment
+    expect(reassignment2AnonymizationId).to.not.equal(reassignment1AnonymizationId)
+    expect(anonymizedProduct2.slug.en).to.contain(reassignment2AnonymizationId)
+    expect(anonymizedProduct2.slug.en).to.not.contain(reassignment1AnonymizationId)
+  })
+})


### PR DESCRIPTION
This PR fixes case when we are removing variants from project one by one and anonymizing product multiple times.